### PR TITLE
improve meme urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Funny Meme](https://i.redd.it/vkrryhucaxpb1.jpg?width=100&height=100)
+![Funny Meme](https://i.redd.it/gvw6yb3h42qb1.jpg?width=100&height=100)
 
 ### Warning: The memes you see here are highly volatile and have a limited lifespan of 5 minutes. So, better hurry up and laugh before they disappear! 😄
 **------------------------------------------------------------------------------------------------------------------------------------------------**

--- a/joke.py
+++ b/joke.py
@@ -42,7 +42,14 @@ def extract_meme_url(meme_data):
             and "url" in meme_data[0]["data"]["children"][0]["data"]
         ):
             meme_url = meme_data[0]["data"]["children"][0]["data"]["url"]
-            return meme_url + "?width=100&height=100"  # Add query string to reduce image size
+            
+            # Check if the URL ends with a common image file extension
+            image_file_extensions = ['.jpg', '.jpeg', '.png', '.gif']
+            if any(meme_url.lower().endswith(ext) for ext in image_file_extensions):
+                return meme_url + "?width=100&height=100"  # Add query string to reduce image size
+            
+            print("URL does not point to an image.")
+            return None
         else:
             print("Unexpected JSON structure in the response.")
             return None


### PR DESCRIPTION
To ensure that you only get picture links (image URLs) and exclude other types of links, you can modify the code to check the file extension of the URL. 
Typically, image URLs have common file extensions ` .jpg, .png, .gif,` etc.