### PR TITLE
Feature added optional show and save image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-![Funny Meme](https://i.redd.it/jk7zn5tbojsb1.jpg?width=100&height=100)
+![Funny Meme](https://i.redd.it/ov2etwu8nhsb1.jpg?width=100&height=100)
 
 
 ### Warning: The memes you see here are highly volatile and have a limited lifespan of 5 minutes. So, better hurry up and laugh before they disappear! 😄

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-![Funny Meme](https://i.redd.it/ov2etwu8nhsb1.jpg?width=100&height=100)
+![Funny Meme](https://i.redd.it/jk7zn5tbojsb1.jpg?width=100&height=100)
 
 
 ### Warning: The memes you see here are highly volatile and have a limited lifespan of 5 minutes. So, better hurry up and laugh before they disappear! 😄


### PR DESCRIPTION
- Added Command-Line Arguments:

1. `--show`:
This argument allows the user to display the fetched meme image. When provided, the code will show the image using the default image viewer.
2. `--save` and `--output`:
This argument enables the user to save the fetched meme image to a file. When provided, the code will save the image to a specified file.

